### PR TITLE
Prefer TBC raid mana consumables

### DIFF
--- a/Scanner/Inventory.lua
+++ b/Scanner/Inventory.lua
@@ -199,6 +199,26 @@ end
 local itemCounts = {}
 local slotItems = {}
 
+local PreferredManaPotionByMapID = {
+    [334] = 32902, -- Tempest Keep: The Eye -> Bottled Nethergon Energy
+    [332] = 32903  -- Serpentshrine Cavern -> Cenarion Mana Salve
+}
+
+local function IsPreferredManaPotionForMap(itemID, currentMap)
+    return currentMap and PreferredManaPotionByMapID[currentMap] == itemID
+end
+
+local function IsBetterManaPotion(candidate, candidateCount, candidatePrice, currentBest, currentMap)
+    local candidateIsPreferred = IsPreferredManaPotionForMap(candidate.id, currentMap)
+    local currentIsPreferred = IsPreferredManaPotionForMap(currentBest.id, currentMap)
+
+    if candidateIsPreferred ~= currentIsPreferred then
+        return candidateIsPreferred
+    end
+
+    return IsBetter(candidate, candidateCount, candidatePrice, currentBest, candidate.manaValue, false)
+end
+
 function ns.ScanBags()
     local playerLevel = ns.CachedPlayerLevel
     local currentMap = ns.CachedMapID
@@ -322,7 +342,7 @@ function ns.ScanBags()
                             end
                             if
                                 data.manaValue > 0 and
-                                    IsBetter(data, totalCount, data.price, best["Mana Potion"], data.manaValue, false)
+                                    IsBetterManaPotion(data, totalCount, data.price, best["Mana Potion"], currentMap)
                              then
                                 local winner = best["Mana Potion"]
                                 winner.id = id


### PR DESCRIPTION
## Summary

- Prefer Bottled Nethergon Energy for the mana potion macro in Tempest Keep: The Eye.
- Prefer Cenarion Mana Salve for the mana potion macro in Serpentshrine Cavern.
- Keep existing best mana potion fallback behavior outside those raids or when the raid item is not present/usable.

## Why

These TBC raid mana consumables restore the same amount as other top mana options, so the existing tie-breaker can choose another 1800-mana item even when the raid-specific consumable should be used.

## Validation

- `luac -p Scanner/Inventory.lua Macro-Builder.lua Core.lua Data/Potions.lua Data/General.lua`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mana potion selection with location awareness: the inventory scanner now intelligently prioritizes mana potions based on your current location for improved gameplay optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gogo1951/Connoisseur/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->